### PR TITLE
-- Fix Auctioneer Fitch (ID: 8719) now opens the Auctionsframe correctly

### DIFF
--- a/sql/updates/world/2014_04_09_creature_template.sql
+++ b/sql/updates/world/2014_04_09_creature_template.sql
@@ -1,0 +1,8 @@
+-- Fix Auctioneer Fitch (ID: 8719) now opens the Auctionsframe correctly
+
+UPDATE creature_template SET gossip_menu_id='0' WHERE entry='8719';
+
+--  Removed the spells Well Fed ( ID: 131828 ) and Prismatic Elixir (134873 ) from spell_group table because they were added in 5.3
+
+DELETE FROM spell_group WHERE spell_id='131828';
+DELETE FROM spell_group WHERE spell_id='134873';

--- a/sql/updates/world/2014_04_09_world.sql
+++ b/sql/updates/world/2014_04_09_world.sql
@@ -1,0 +1,2 @@
+-- Spell does not exist
+DELETE FROM spell_group WHERE spell_id='52109';


### PR DESCRIPTION
-- Fix Auctioneer Fitch (ID: 8719) now opens the Auctionsframe correctly
-- Removed the spells Well Fed ( ID: 131828 ) and Prismatic Elixir (134873 ) from spell_group table because they were added in patch 5.3
